### PR TITLE
解决当父View释放时，当前视图因为被Timer强引用而不能释放的问题

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView.m
@@ -151,7 +151,14 @@ NSString * const ID = @"cycleCell";
     _pageControl.frame = CGRectMake(x, y, size.width, size.height);
     [_pageControl sizeToFit];
 }
-
+//解决当父View释放时，当前视图因为被Timer强引用而不能释放的问题
+- (void)willMoveToSuperview:(UIView *)newSuperview
+{
+    if (!newSuperview) {
+        [_timer invalidate];
+        _timer = nil;
+    }
+}
 
 #pragma mark - UICollectionViewDataSource
 


### PR DESCRIPTION
你好，我在使用时发现当父视图要销毁时，SDCycleScrollView被Timer强引用而不能释放。我复写了willMoveToSuperview方法，希望可以解决这个问题。