### PR TITLE
修改Pop时崩溃问题

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView.m
@@ -40,6 +40,11 @@ NSString * const ID = @"cycleCell";
 
 @implementation SDCycleScrollView
 
+- (void)dealloc
+{
+    _mainView.delegate = nil;
+    _mainView.dataSource = nil;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame
 {


### PR DESCRIPTION
解决SDCycleScrollView在销毁时可能造成的崩溃问题