### PR TITLE
解决图片数量由多变少时一定几率崩溃的问题

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -273,6 +273,10 @@ NSString * const ID = @"cycleCell";
 
 - (void)setImagePathsGroup:(NSArray *)imagePathsGroup
 {
+    if (imagePathsGroup.count < _imagePathsGroup.count) {
+        [_mainView setContentOffset:CGPointZero animated:NO];
+    }
+    
     _imagePathsGroup = imagePathsGroup;
     
     _totalItemsCount = self.infiniteLoop ? self.imagePathsGroup.count * 100 : self.imagePathsGroup.count;


### PR DESCRIPTION
当刷新页面，重新对SDCycleScrollView的imageURLStringsGroup属性赋值，图片个数由多变少，setImagePathsGroup执行后，collectionView更新了。紧接着automaticScroll被执行，int currentIndex = _mainView.contentOffset.x / _flowLayout.itemSize.width 。由于_mainView.contentOffset.x依然可能很大，导致currentIndex超出了_mainView的边界，导致崩溃。

崩溃信息：“NSInvalidArgumentException(SIGABRT)
attempt to scroll to invalid index path: <NSIndexPath: 0x1756d300> {length = 2, path = 0 - 297}
-[SDCycleScrollView automaticScroll] (SDCycleScrollView.m:372)”