### PR TITLE
解决automaticScroll有时会出现NSIndexPath越界的问题

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -366,8 +366,13 @@ NSString * const ID = @"cycleCell";
 - (void)automaticScroll
 {
     if (0 == _totalItemsCount) return;
-    int currentIndex = _mainView.contentOffset.x / _flowLayout.itemSize.width;
-    int targetIndex = currentIndex + 1;
+    NSInteger currentIndex = _mainView.contentOffset.x / _flowLayout.itemSize.width;
+    NSInteger targetIndex = currentIndex + 1;
+    
+    if (targetIndex > _totalItemsCount) {
+        targetIndex = _totalItemsCount;
+    }
+    
     if (targetIndex == _totalItemsCount) {
         if (self.infiniteLoop) {
             targetIndex = _totalItemsCount * 0.5;


### PR DESCRIPTION
在automaticScroll方法里
最后一行：
[_mainView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:targetIndex inSection:0] atScrollPosition:UICollectionViewScrollPositionNone animated:YES];
indexPath可能会越界，而引发crash