### PR TITLE
custom cell awakeFromNib setting bug.

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -65,10 +65,14 @@ NSString * const ID = @"cycleCell";
     return self;
 }
 
-- (void)awakeFromNib
+- (instancetype)initWithCoder:(NSCoder *)coder
 {
-    [self initialization];
-    [self setupMainView];
+    self = [super initWithCoder:coder];
+    if (self) {
+        [self initialization];
+        [self setupMainView];
+    }
+    return self;
 }
 
 - (void)initialization


### PR DESCRIPTION
修复在UITableViewCell的awakeFromNib方法中，设置sdCycleScrollView的属性无效。

问题代码：

#import "TMRouteDPlaceCell.h"
#import <SDCycleScrollView.h>

@interface TMRouteDPlaceCell () <SDCycleScrollViewDelegate>

/**
 轮播图
 */
@property (weak, nonatomic) IBOutlet SDCycleScrollView *cycleSV;

@end

@implementation TMRouteDPlaceCell

- (void)awakeFromNib {
    [super awakeFromNib];
    
    self.cycleSV.delegate = self;
    self.cycleSV.autoScroll = NO;
    self.cycleSV.showPageControl = NO;
}

- (void)setDataDict:(NSDictionary *)dataDict {
    _dataDict = dataDict;
    
    // 图片轮播图
    {
        NSArray *imageArray = dataDict[@"placeImages"];
        self.cycleSV.imageURLStringsGroup = imageArray;
    }
    
}

@end

原因：
SDScrollView的 awakeFromNib，在cell的awakeFromNib之后调用，导致之前设置的属性被覆盖。

修复：
视图的初始化调用的是initWithFrame: 或 initWithCoder: 方法，将初始化方法写在awakeFromNib中欠妥。