### PR TITLE
当使用本地图片（动态更新的图片）时，本地图片更新后读取到的图片仍旧时第一次加载的内存中的图片

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.h
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.h
@@ -87,6 +87,8 @@ typedef enum {
 /** 本地图片数组 */
 @property (nonatomic, strong) NSArray *localizationImageNamesGroup;
 
+/** 默认YES 如果使用的本地图片是自己动态生成的图片 是不能使用缓存的数据 需要每次从disk中读取*/
+@property (nonatomic, assign) BOOL useMemoryImage;
 
 
 

--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -83,6 +83,7 @@ NSString * const ID = @"cycleCell";
     _autoScroll = YES;
     _infiniteLoop = YES;
     _showPageControl = YES;
+    _useMemoryImage = YES;
     _pageControlDotSize = kCycleScrollViewInitialPageControlDotSize;
     _pageControlBottomOffset = 0;
     _pageControlRightOffset = 0;
@@ -550,10 +551,15 @@ NSString * const ID = @"cycleCell";
         if ([imagePath hasPrefix:@"http"]) {
             [cell.imageView sd_setImageWithURL:[NSURL URLWithString:imagePath] placeholderImage:self.placeholderImage];
         } else {
-            UIImage *image = [UIImage imageNamed:imagePath];
-            if (!image) {
-                [UIImage imageWithContentsOfFile:imagePath];
+            UIImage *image = nil;
+            if (_useMemoryImage) {
+                image = [UIImage imageNamed:imagePath];
             }
+            
+            if (!image) {
+                image = [UIImage imageWithContentsOfFile:imagePath];
+            }
+
             cell.imageView.image = image;
         }
     } else if (!self.onlyDisplayText && [imagePath isKindOfClass:[UIImage class]]) {


### PR DESCRIPTION
当使用本地图片（动态更新的图片）时，本地图片更新后读取到的图片仍旧时第一次加载的内存中的图片。
增加useMemoryImage属性，默认为YES，优先使用内存的资源；为NO时实时读取沙盒资源。