### PR TITLE
解决cell复用导致文字标题label显示bug（4张图片，2或3个文字标题时，标题label显示有问题）

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCollectionViewCell.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCollectionViewCell.m
@@ -86,7 +86,9 @@
 {
     _title = [title copy];
     _titleLabel.text = [NSString stringWithFormat:@"   %@", title];
-    if (_titleLabel.hidden) {
+    if ([_title isEqualToString: @""]) {
+        _titleLabel.hidden = YES;
+    } else {
         _titleLabel.hidden = NO;
     }
 }

--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -595,6 +595,8 @@ NSString * const ID = @"SDCycleScrollViewCell";
     
     if (_titlesGroup.count && itemIndex < _titlesGroup.count) {
         cell.title = _titlesGroup[itemIndex];
+    } else {
+        cell.title = @"";
     }
     
     if (!cell.hasConfigured) {


### PR DESCRIPTION
当图片数组中有4张图片，但是标题数组中有3个标题时，正常情况下第4张图片应该是隐藏的，但是现在其下方的文字介绍显示出来了并且展示的是第一张图片的标题；同样2个标题4张图的时候也会触发 @gsdios 