### PR TITLE
去掉collectionView 刷新时的闪屏

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -309,7 +309,10 @@ NSString * const ID = @"SDCycleScrollViewCell";
     }
     
     [self setupPageControl];
-    [self.mainView reloadData];
+    [UIView performWithoutAnimation:^{
+        [self.mainView reloadData];
+    }];
+    
 }
 
 - (void)setImageURLStringsGroup:(NSArray *)imageURLStringsGroup


### PR DESCRIPTION
collectionView 刷新有个闪屏的隐式动画，当在cell 中使用SDCycle的时候会经常触发