### PR TITLE
PageControl 太多导致渲染太慢，界面卡

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -308,7 +308,9 @@ NSString * const ID = @"SDCycleScrollViewCell";
         [self setAutoScroll:NO];
     }
     
-    [self setupPageControl];
+    if (self.showPageControl) {
+        [self setupPageControl];
+    }
     [self.mainView reloadData];
 }
 


### PR DESCRIPTION
PageControl 太多导致渲染太慢，界面卡,  比如有读取相册中所有内容，几百张图片。