### PR TITLE
适配ios11  contentInsetAdjustmentBehavior

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -147,6 +147,11 @@ NSString * const ID = @"SDCycleScrollViewCell";
     mainView.delegate = self;
     mainView.scrollsToTop = NO;
     [self addSubview:mainView];
+    //ios11 兼容性适配
+    if (@available(iOS 11.0, *)) {
+        mainView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+        mainView.insetsLayoutMarginsFromSafeArea = NO;
+    }
     _mainView = mainView;
 }
 


### PR DESCRIPTION
1 ios11 兼容性适配
2 解决table headerView下拉放大时（iOS 11）出现闪动的bug
