### PR TITLE
调整网络不好时的占位图显示模式，和用户设置的模式一致。

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -351,6 +351,11 @@ NSString * const ID = @"SDCycleScrollViewCell";
     }
 }
 
+- (void)setBannerImageViewContentMode:(UIViewContentMode)bannerImageViewContentMode {
+    self.backgroundImageView.contentMode = bannerImageViewContentMode;
+    _bannerImageViewContentMode = bannerImageViewContentMode;
+}
+
 - (void)disableScrollGesture {
     self.mainView.canCancelContentTouches = NO;
     for (UIGestureRecognizer *gesture in self.mainView.gestureRecognizers) {


### PR DESCRIPTION
如果不允许切换模式，会出现占位图边缘留有黑边的情况。