### PR TITLE
修复了加载多张图片作为banner的时候内存暴增甚至崩溃的问题。

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.h
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.h
@@ -148,6 +148,9 @@ typedef enum {
 /** 是否显示分页控件 */
 @property (nonatomic, assign) BOOL showPageControl;
 
+/** 是否需要分页控件，默认为YES，如果只设置隐藏，在需要加载很多张图片的时候会增加大量内存 */
+@property (nonatomic, assign) BOOL needPageControl;
+
 /** 是否在只有一张图时隐藏pagecontrol，默认为YES */
 @property(nonatomic) BOOL hidesForSinglePage;
 

--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -84,6 +84,7 @@ NSString * const ID = @"SDCycleScrollViewCell";
     _autoScroll = YES;
     _infiniteLoop = YES;
     _showPageControl = YES;
+    _needPageControl = YES;
     _pageControlDotSize = kCycleScrollViewInitialPageControlDotSize;
     _pageControlBottomOffset = 0;
     _pageControlRightOffset = 0;
@@ -309,8 +310,9 @@ NSString * const ID = @"SDCycleScrollViewCell";
         self.mainView.scrollEnabled = NO;
         [self invalidateTimer];
     }
-    
-    [self setupPageControl];
+    if(self.needPageControl){   //需要的时候才添加分页控件
+        [self setupPageControl];
+    }
     [self.mainView reloadData];
 }
 


### PR DESCRIPTION
我在使用这个控件用来加载数百张图片的时候（项目需求），发现内存增长巨大，最后发现是由于分页控件导致的，所以这里修改了这个问题，希望能处理一下