### PR TITLE
修复轮播view宽度为小数的时候播放错乱的情况

### DIFF
--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -150,6 +150,14 @@ NSString * const ID = @"SDCycleScrollViewCell";
     _mainView = mainView;
 }
 
+- (void)scrollToItemAtIndex:(NSInteger)index animated:(BOOL)animated {
+    
+    //在ipx上宽度为小数的时候会出现错乱的情况,所以不能使用
+//    [_mainView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:index inSection:0] atScrollPosition:UICollectionViewScrollPositionNone animated:YES];
+    
+    //下面方法这样避免了轮播view宽度为小数的时候轮播错乱的情况
+    [_mainView setContentOffset:CGPointMake(index*_flowLayout.itemSize.width, 0) animated:animated];
+}
 
 #pragma mark - properties
 
@@ -442,11 +450,11 @@ NSString * const ID = @"SDCycleScrollViewCell";
     if (targetIndex >= _totalItemsCount) {
         if (self.infiniteLoop) {
             targetIndex = _totalItemsCount * 0.5;
-            [_mainView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:targetIndex inSection:0] atScrollPosition:UICollectionViewScrollPositionNone animated:NO];
+            [self scrollToItemAtIndex:targetIndex animated:NO];
         }
         return;
     }
-    [_mainView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:targetIndex inSection:0] atScrollPosition:UICollectionViewScrollPositionNone animated:YES];
+    [self scrollToItemAtIndex:targetIndex animated:YES];
 }
 
 - (int)currentIndex
@@ -498,7 +506,7 @@ NSString * const ID = @"SDCycleScrollViewCell";
         }else{
             targetIndex = 0;
         }
-        [_mainView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:targetIndex inSection:0] atScrollPosition:UICollectionViewScrollPositionNone animated:NO];
+        [self scrollToItemAtIndex:targetIndex animated:NO];
     }
     
     CGSize size = CGSizeZero;
@@ -561,7 +569,7 @@ NSString * const ID = @"SDCycleScrollViewCell";
 {
     long targetIndex = [self currentIndex];
     if (targetIndex < _totalItemsCount) {
-        [_mainView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:targetIndex inSection:0] atScrollPosition:UICollectionViewScrollPositionNone animated:NO];
+        [self scrollToItemAtIndex:targetIndex animated:NO];
     }
 }
 

--- a/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
+++ b/SDCycleScrollView/Lib/SDCycleScrollView/SDCycleScrollView.m
@@ -156,7 +156,12 @@ NSString * const ID = @"SDCycleScrollViewCell";
 //    [_mainView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:index inSection:0] atScrollPosition:UICollectionViewScrollPositionNone animated:YES];
     
     //下面方法这样避免了轮播view宽度为小数的时候轮播错乱的情况
-    [_mainView setContentOffset:CGPointMake(index*_flowLayout.itemSize.width, 0) animated:animated];
+    if (_flowLayout.scrollDirection == UICollectionViewScrollDirectionHorizontal) {
+        [_mainView setContentOffset:CGPointMake(index*_flowLayout.itemSize.width, 0) animated:animated];
+    }else{
+        [_mainView setContentOffset:CGPointMake(0, index*_flowLayout.itemSize.width) animated:animated];
+    }
+    
 }
 
 #pragma mark - properties

--- a/SDCycleScrollView/ViewController.m
+++ b/SDCycleScrollView/ViewController.m
@@ -101,7 +101,9 @@
 // >>>>>>>>>>>>>>>>>>>>>>>>> demo轮播图2 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     
     // 网络加载 --- 创建带标题的图片轮播器
-    SDCycleScrollView *cycleScrollView2 = [SDCycleScrollView cycleScrollViewWithFrame:CGRectMake(0, 280, w, 180) delegate:self placeholderImage:[UIImage imageNamed:@"placeholder"]];
+    CGFloat width = 22.08; //在ipX上当滑动的轮播的View的宽度为小数时,轮播错误,会出现播放前两个,后面不播的情况
+//    CGFloat width = 22; //当轮播的view宽度为整数的时候,正常播放
+    SDCycleScrollView *cycleScrollView2 = [SDCycleScrollView cycleScrollViewWithFrame:CGRectMake(width, 280, w-width*2, 180) delegate:self placeholderImage:[UIImage imageNamed:@"placeholder"]];
     
     cycleScrollView2.pageControlAliment = SDCycleScrollViewPageContolAlimentRight;
     cycleScrollView2.titlesGroup = titles;


### PR DESCRIPTION
如上描述,在ipx上你会看的播放错乱的情况,宽度为整数的时候正常播放